### PR TITLE
build: remove xblock-lti-consumer

### DIFF
--- a/requirements/xblocks.txt
+++ b/requirements/xblocks.txt
@@ -16,4 +16,3 @@
 -e git+https://github.com/eol-uchile/pdfXBlock@1ef65825dfcffbaa4aeec32451f4d495a78ab87c#egg=pdf-xblock
 -e git+https://github.com/eol-uchile/xblock-drag-and-drop-v2@58d8a691cf9210220925f3d2957b39a377f6704c#egg=xblock-drag-and-drop-v2
 -e git+https://github.com/eol-uchile/xblock-in-video-quiz@1555dcbd96341f19b76f915f0135f46192869796#egg=xblock_in_video_quiz
--e git+https://github.com/eol-uchile/xblock-lti-consumer@b1384343be9ae1a4d6de5760a3a5c1475a3024cf#egg=lti-consumer-xblock


### PR DESCRIPTION
Se elimina xblock-lti-consumer para utilizar el vanilla instalado en vanilla